### PR TITLE
correct arg name and explanation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,6 +31,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+    # - name: Test with pytest
+    #   run: |
+    #     pytest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
           shortcut_api_token: ${{ secrets.SHORTCUT_API_TOKEN }}
           shortcut_default_user_name: $SHORTCUT_USER_NAME
           shortcut_workflow: $SHORTCUT_WORKFLOW_NAME
-          shortcut_group: $SHORTCUT_GROUP_NAME  # optional
+          shortcut_team: $SHORTCUT_TEAM_NAME  # optional
           shortcut_project: $SHORTCUT_PROJECT_NAME # optional
           gh_sc_user_map: $ID_MAP  # optional
           gh_action_sc_state_map: $ACTION_STATE_MAP  # optional
@@ -41,7 +41,7 @@ jobs:
     - Name of a Shortcut user that will become "Requester" of the created story when no Github-Shortcut user map is specified.
 - `shortcut_workflow`
     - Shortcut workflow that the story is created.
-- `shortcut_group`, optional
+- `shortcut_team`, optional
     - Shortcut team responsible for the story.
 - `shortcut_project`, optional
     - Shortcut project that the story belongs.
@@ -60,11 +60,11 @@ jobs:
             ```
             '{"opened": "Unscheduled", "closed": "Completed"}'
             ``` 
-    - For the following states, default values will be used if not specified.
+    - For the following event types, default values will be used if not specified.
         - "opened": first state of the workflow specified above
         - "reopened": the same as "opened"
         - "closed": last state of the workflow specified above
-        - For the others, the current workflow state remain unchanged.
+        - For the others, the current workflow state remains unchanged.
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ inputs:
   github_token:
     description: "github token"
     required: true
-  github_issue_number:
-    description: "number of the issue created"
-    required: true
   shortcut_api_token:
     description: "shortcut api token"
     required: true
@@ -16,15 +13,20 @@ inputs:
   shortcut_workflow:
     description: "shortcut workflow name that story is created"
     required: true
-  shortcut_group:
+  shortcut_team:
     description: "shortcut team responsible for story"
     required: false
   shortcut_project:
     description: "shortcut project that story belongs"
     required: false
   gh_sc_user_map:
-    description: "map of github user to shortcut user"
+    description: "map from github user to shortcut user"
     required: false
+  gh_action_sc_state_map:
+    description: "map from github action trigger to shortcut workflow state"
+    required: false
+
+
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
Signed-off-by: yongsub <yongsub@makinarocks.ai>

- Unused argument `github_issue_number` is removed from `action.yml` and `README.md`.
- Unused argument `shortcut_group` is fixed to `shortcut_team`.